### PR TITLE
Cw 1353 fix literals blocks

### DIFF
--- a/docroot/sites/all/modules/osha/osha/osha.translate.inc
+++ b/docroot/sites/all/modules/osha/osha/osha.translate.inc
@@ -74,6 +74,6 @@ function osha_get_translatable_strings() {
     '- Any -',
     'More',
     'Press contacts',
-    'EU-OSHA in the media'
+    'EU-OSHA in the media',
   );
 }

--- a/docroot/sites/all/modules/osha/osha_alert_service/osha_alert_service.features.fe_block_settings.inc
+++ b/docroot/sites/all/modules/osha/osha_alert_service/osha_alert_service.features.fe_block_settings.inc
@@ -48,7 +48,7 @@ function osha_alert_service_default_fe_block_settings() {
         'weight' => -28,
       ),
     ),
-    'title' => '',
+    'title' => '<none>',
     'visibility' => 0,
   );
 
@@ -251,7 +251,7 @@ node/5322',
         'weight' => 1,
       ),
     ),
-    'title' => 'Events feed',
+    'title' => '<none>',
     'visibility' => 1,
   );
 
@@ -331,7 +331,7 @@ node/5322',
         'weight' => 1,
       ),
     ),
-    'title' => 'Job vacancies feed',
+    'title' => '<none>',
     'visibility' => 1,
   );
 
@@ -412,7 +412,7 @@ highlights',
         'weight' => 1,
       ),
     ),
-    'title' => 'Publication feed',
+    'title' => '<none>',
     'visibility' => 1,
   );
 
@@ -452,7 +452,7 @@ highlights',
         'weight' => -5,
       ),
     ),
-    'title' => 'Seminar feed',
+    'title' => '<none>',
     'visibility' => 1,
   );
 

--- a/docroot/sites/all/modules/osha/osha_alert_service/osha_alert_service.features.fe_block_settings.inc
+++ b/docroot/sites/all/modules/osha/osha_alert_service/osha_alert_service.features.fe_block_settings.inc
@@ -251,7 +251,7 @@ node/5322',
         'weight' => 1,
       ),
     ),
-    'title' => '',
+    'title' => 'Events feed',
     'visibility' => 1,
   );
 
@@ -331,7 +331,7 @@ node/5322',
         'weight' => 1,
       ),
     ),
-    'title' => '',
+    'title' => 'Job vacancies feed',
     'visibility' => 1,
   );
 
@@ -412,7 +412,7 @@ highlights',
         'weight' => 1,
       ),
     ),
-    'title' => '',
+    'title' => 'Publication feed',
     'visibility' => 1,
   );
 
@@ -452,7 +452,7 @@ highlights',
         'weight' => -5,
       ),
     ),
-    'title' => '',
+    'title' => 'Seminar feed',
     'visibility' => 1,
   );
 

--- a/docroot/sites/all/modules/osha/osha_blocks/osha_blocks.features.fe_block_settings.inc
+++ b/docroot/sites/all/modules/osha/osha_blocks/osha_blocks.features.fe_block_settings.inc
@@ -12,6 +12,46 @@ function osha_blocks_default_fe_block_settings() {
 
   $export['version'] = '2.0';
 
+  $export['block-seminar_back_to_seminars_link'] = array(
+    'cache' => -1,
+    'custom' => 0,
+    'i18n_block_language' => array(),
+    'i18n_mode' => 1,
+    'machine_name' => 'seminar_back_to_seminars_link',
+    'module' => 'block',
+    'node_types' => array(),
+    'pages' => '',
+    'roles' => array(),
+    'themes' => array(
+      'bartik' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'bartik',
+        'weight' => 0,
+      ),
+      'osha_admin' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'osha_admin',
+        'weight' => 0,
+      ),
+      'osha_frontend' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'osha_frontend',
+        'weight' => 1,
+      ),
+      'seven' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'seven',
+        'weight' => 0,
+      ),
+    ),
+    'title' => '',
+    'visibility' => 0,
+  );
+
   $export['blockgroup-related'] = array(
     'cache' => -1,
     'custom' => 0,

--- a/docroot/sites/all/modules/osha/osha_blocks/osha_blocks.features.fe_block_settings.inc
+++ b/docroot/sites/all/modules/osha/osha_blocks/osha_blocks.features.fe_block_settings.inc
@@ -12,46 +12,6 @@ function osha_blocks_default_fe_block_settings() {
 
   $export['version'] = '2.0';
 
-  $export['block-seminar_back_to_seminars_link'] = array(
-    'cache' => -1,
-    'custom' => 0,
-    'i18n_block_language' => array(),
-    'i18n_mode' => 1,
-    'machine_name' => 'seminar_back_to_seminars_link',
-    'module' => 'block',
-    'node_types' => array(),
-    'pages' => '',
-    'roles' => array(),
-    'themes' => array(
-      'bartik' => array(
-        'region' => '',
-        'status' => 0,
-        'theme' => 'bartik',
-        'weight' => 0,
-      ),
-      'osha_admin' => array(
-        'region' => '',
-        'status' => 0,
-        'theme' => 'osha_admin',
-        'weight' => 0,
-      ),
-      'osha_frontend' => array(
-        'region' => '',
-        'status' => 0,
-        'theme' => 'osha_frontend',
-        'weight' => 1,
-      ),
-      'seven' => array(
-        'region' => '',
-        'status' => 0,
-        'theme' => 'seven',
-        'weight' => 0,
-      ),
-    ),
-    'title' => '',
-    'visibility' => 0,
-  );
-
   $export['blockgroup-related'] = array(
     'cache' => -1,
     'custom' => 0,
@@ -232,7 +192,7 @@ function osha_blocks_default_fe_block_settings() {
         'weight' => 0,
       ),
     ),
-    'title' => '',
+    'title' => 'OSHwiki featured articles',
     'visibility' => 0,
   );
 

--- a/docroot/sites/all/modules/osha/osha_blocks/osha_blocks.translate.inc
+++ b/docroot/sites/all/modules/osha/osha_blocks/osha_blocks.translate.inc
@@ -4,5 +4,6 @@ function osha_blocks_get_translatable_strings() {
   return array(
     'EU-OSHA archived content',
     'OSHwiki featured articles',
+    'This page is also available in:',
   );
 }

--- a/docroot/sites/all/modules/osha/osha_events/osha_events.features.fe_block_settings.inc
+++ b/docroot/sites/all/modules/osha/osha_events/osha_events.features.fe_block_settings.inc
@@ -50,7 +50,7 @@ function osha_events_default_fe_block_settings() {
         'weight' => 0,
       ),
     ),
-    'title' => '',
+    'title' => '<none>',
     'visibility' => 0,
   );
 

--- a/docroot/sites/all/modules/osha/osha_fop_page/osha_fop_page.features.fe_block_settings.inc
+++ b/docroot/sites/all/modules/osha/osha_fop_page/osha_fop_page.features.fe_block_settings.inc
@@ -133,7 +133,7 @@ node/7116',
         'weight' => 0,
       ),
     ),
-    'title' => '',
+    'title' => '<none>',
     'visibility' => 0,
   );
 

--- a/docroot/sites/all/modules/osha/osha_fop_page/osha_fop_page.info
+++ b/docroot/sites/all/modules/osha/osha_fop_page/osha_fop_page.info
@@ -65,4 +65,4 @@ features[variable][] = node_submitted_fop_page
 features[variable][] = pathauto_node_fop_page_pattern
 features[views_view][] = fop_flags
 features[views_view][] = fop_page_links
-mtime = 1423645167
+mtime = 1423851747

--- a/docroot/sites/all/modules/osha/osha_fop_page/osha_fop_page.module
+++ b/docroot/sites/all/modules/osha/osha_fop_page/osha_fop_page.module
@@ -56,3 +56,12 @@ function osha_fop_page_node_presave($node) {
     }
   }
 }
+
+
+/**
+ * Implements hook_osha_tmgmt_i18n_string_list().
+ */
+function osha_fop_page_osha_tmgmt_i18n_string_list() {
+  module_load_include('inc', 'osha_fop_page', 'osha_fop_page.translations');
+  return osha_fop_page_get_translatable_strings();
+}

--- a/docroot/sites/all/modules/osha/osha_fop_page/osha_fop_page.translations.inc
+++ b/docroot/sites/all/modules/osha/osha_fop_page/osha_fop_page.translations.inc
@@ -1,0 +1,6 @@
+<?php
+
+function osha_fop_page_get_translatable_strings() {
+  return array(
+  );
+}

--- a/docroot/sites/all/modules/osha/osha_newsletter/osha_newsletter.features.fe_block_settings.inc
+++ b/docroot/sites/all/modules/osha/osha_newsletter/osha_newsletter.features.fe_block_settings.inc
@@ -130,7 +130,7 @@ node/9',
         'weight' => -30,
       ),
     ),
-    'title' => 'Subscribe to EU-OSHA Newsletter',
+    'title' => 'OSHMail newsletter',
     'visibility' => 0,
   );
 
@@ -171,7 +171,7 @@ node/9',
         'weight' => 0,
       ),
     ),
-    'title' => '<none>',
+    'title' => 'OSHMail newsletter',
     'visibility' => 1,
   );
 

--- a/docroot/sites/all/modules/osha/osha_newsletter/osha_newsletter.features.fe_block_settings.inc
+++ b/docroot/sites/all/modules/osha/osha_newsletter/osha_newsletter.features.fe_block_settings.inc
@@ -90,7 +90,7 @@ node/9',
         'weight' => 0,
       ),
     ),
-    'title' => '',
+    'title' => 'Display the latest newsletters',
     'visibility' => 1,
   );
 
@@ -130,7 +130,7 @@ node/9',
         'weight' => -30,
       ),
     ),
-    'title' => '',
+    'title' => 'Subscribe to EU-OSHA Newsletter',
     'visibility' => 0,
   );
 
@@ -171,7 +171,7 @@ node/9',
         'weight' => 0,
       ),
     ),
-    'title' => '',
+    'title' => '<none>',
     'visibility' => 1,
   );
 

--- a/docroot/sites/all/modules/osha/osha_press_contact/osha_press_contact.translations.inc
+++ b/docroot/sites/all/modules/osha/osha_press_contact/osha_press_contact.translations.inc
@@ -10,6 +10,7 @@ function osha_press_contact_get_translatable_strings() {
     'Phone',
     'Press contact',
     'Press contacts',
-    '<a class="press-kit-link" href="/node/5428">EU-OSHA Press kit</a>'
+    '<a class="press-kit-link" href="/node/5428">EU-OSHA Press kit</a>',
+    'Focal points\' contact details',
   );
 }

--- a/docroot/sites/all/modules/osha/osha_press_release/osha_press_release.features.fe_block_settings.inc
+++ b/docroot/sites/all/modules/osha/osha_press_release/osha_press_release.features.fe_block_settings.inc
@@ -128,7 +128,7 @@ function osha_press_release_default_fe_block_settings() {
         'weight' => 4,
       ),
     ),
-    'title' => '',
+    'title' => 'Become a media partner',
     'visibility' => 0,
   );
 
@@ -168,7 +168,7 @@ function osha_press_release_default_fe_block_settings() {
         'weight' => 3,
       ),
     ),
-    'title' => '',
+    'title' => 'Join our news distribution list',
     'visibility' => 0,
   );
 

--- a/docroot/sites/all/modules/osha/osha_press_release/osha_press_release.translations.inc
+++ b/docroot/sites/all/modules/osha/osha_press_release/osha_press_release.translations.inc
@@ -31,5 +31,6 @@ function osha_press_release_get_translatable_strings() {
     'What\'s new',
     'Links',
     'Notes to editor',
+    'Follow us on:',
   );
 }

--- a/docroot/sites/all/themes/osha_frontend/templates/block--osha_blocks--oshwiki_featured_articles.tpl.php
+++ b/docroot/sites/all/themes/osha_frontend/templates/block--osha_blocks--oshwiki_featured_articles.tpl.php
@@ -10,7 +10,7 @@
 <div id="<?php print $block_html_id; ?>" class="<?php print $classes; ?>"<?php print $attributes; ?>>
   <?php print render($title_prefix); ?>
   <?php if ($title): ?>
-    <div class="related_wiki_head"><span><?php print t('OSHwiki featured articles');?><span></div>
+    <div class="related_wiki_head"><span><?php print t($title);?><span></div>
   <?php endif; ?>
   <?php print render($title_suffix); ?>
   <?php print $content; ?>

--- a/docroot/sites/all/themes/osha_frontend/templates/block.tpl.php
+++ b/docroot/sites/all/themes/osha_frontend/templates/block.tpl.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @file
+ * Returns the HTML for a block.
+ *
+ * Complete documentation for this file is available online.
+ * @see https://drupal.org/node/1728246
+ */
+?>
+<div id="<?php print $block_html_id; ?>" class="<?php print $classes; ?>"<?php print $attributes; ?>>
+
+  <?php print render($title_prefix); ?>
+  <?php if ($title): ?>
+    <h2<?php print $title_attributes; ?>><?php print t($title); ?></h2>
+  <?php endif; ?>
+  <?php print render($title_suffix); ?>
+
+  <?php print $content; ?>
+
+</div>

--- a/docroot/sites/all/themes/osha_frontend/templates/views-view--block.tpl.php
+++ b/docroot/sites/all/themes/osha_frontend/templates/views-view--block.tpl.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * @file
+ * Main view template.
+ *
+ * Variables available:
+ * - $classes_array: An array of classes determined in
+ *   template_preprocess_views_view(). Default classes are:
+ *     .view
+ *     .view-[css_name]
+ *     .view-id-[view_name]
+ *     .view-display-id-[display_name]
+ *     .view-dom-id-[dom_id]
+ * - $classes: A string version of $classes_array for use in the class attribute
+ * - $css_name: A css-safe version of the view name.
+ * - $css_class: The user-specified classes names, if any
+ * - $header: The view header
+ * - $footer: The view footer
+ * - $rows: The results of the view query, if any
+ * - $empty: The empty text to display if the view is empty
+ * - $pager: The pager next/prev links to display, if any
+ * - $exposed: Exposed widget form/info to display
+ * - $feed_icon: Feed icon to display, if any
+ * - $more: A link to view more, if any
+ *
+ * @ingroup views_templates
+ */
+?>
+<div class="<?php print $classes; ?>">
+<?php print render($title_prefix); ?>
+<?php if ($title): ?>
+  <?php print $title; ?>
+<?php endif; ?>
+<?php print render($title_suffix); ?>
+<?php if ($header): ?>
+  <div class="view-header">
+    <?php print $header; ?>
+  </div>
+<?php endif; ?>
+
+<?php if ($exposed): ?>
+  <div class="view-filters">
+    <?php print $exposed; ?>
+  </div>
+<?php endif; ?>
+
+<?php if ($attachment_before): ?>
+  <div class="attachment attachment-before">
+    <?php print $attachment_before; ?>
+  </div>
+<?php endif; ?>
+
+<?php if ($rows): ?>
+  <div class="view-content">
+    <?php print $rows; ?>
+  </div>
+<?php elseif ($empty): ?>
+  <div class="view-empty">
+    <?php print $empty; ?>
+  </div>
+<?php endif; ?>
+
+<?php if ($pager): ?>
+  <?php print $pager; ?>
+<?php endif; ?>
+
+<?php if ($attachment_after): ?>
+  <div class="attachment attachment-after">
+    <?php print $attachment_after; ?>
+  </div>
+<?php endif; ?>
+
+<?php if ($more): ?>
+  <?php print $more; ?>
+<?php endif; ?>
+
+<?php if ($footer): ?>
+  <div class="view-footer">
+    <?php print $footer; ?>
+  </div>
+<?php endif; ?>
+
+<?php if ($feed_icon): ?>
+  <div class="feed-icon">
+    <?php print $feed_icon; ?>
+  </div>
+<?php endif; ?>
+
+</div><?php /* class view */ ?>


### PR DESCRIPTION
For other blocks that views-blocks, the title must be set in block interface (overwrite the one from code) to be passed in t() in block.tpl
For views blocks, the title block must be left empty, to be the one from views interface (it's passed in t() from view module)