### PR TITLE
cw-1371 Remove HTMLT Doctype from summary and body

### DIFF
--- a/docroot/sites/all/modules/osha/osha_migration/utils.api.inc
+++ b/docroot/sites/all/modules/osha/osha_migration/utils.api.inc
@@ -741,8 +741,8 @@ class MigrationUtil {
         $imgSrc = str_replace('//', '/', $imgSrc);
         $img->setAttribute('src', $imgSrc);
       }
-      $text = $dom->saveHTML();
-      $text = preg_replace('~<(?:!DOCTYPE|/?(?:html|head|body))[^>]*>\s*~i', '', $text);
+      $html = OshaTMGMTRetranslate::getDOMNodeList($dom->saveHTML());
+      $text = OshaTMGMTRetranslate::getHTML($html);
     }
 
     return $text;

--- a/docroot/sites/all/modules/osha/osha_migration/utils.api.inc
+++ b/docroot/sites/all/modules/osha/osha_migration/utils.api.inc
@@ -742,6 +742,7 @@ class MigrationUtil {
         $img->setAttribute('src', $imgSrc);
       }
       $text = $dom->saveHTML();
+      $text = preg_replace('~<(?:!DOCTYPE|/?(?:html|head|body))[^>]*>\s*~i', '', $text);
     }
 
     return $text;


### PR DESCRIPTION
La parsarea textului pentru modificarea src-ului imaginilor, summary si body erau salvate cu tot cu Doctype, html si body tag, ceea ce duce si la crearea unui paragraf gol.