### PR TITLE
MDR-2325 Remove space between two note editors in the press release

### DIFF
--- a/docroot/sites/all/themes/osha_frontend/js/stikcy_issues.js
+++ b/docroot/sites/all/themes/osha_frontend/js/stikcy_issues.js
@@ -21,6 +21,15 @@ jQuery(document).ready(function() {
 			}
 		});
 
+
+	if( $('.node-type-press-release article.node-press-release .field p') ){
+		$('.node-type-press-release article.node-press-release .field p').each(function( index ) {
+			if( $( this ).html() == '&nbsp;' || $( this ).html() == '<strong>&nbsp;</strong>'){
+				$( this ).remove();
+			}
+		});
+	}
+
 	});
 })( jQuery );
 


### PR DESCRIPTION
Fix MDR-2325 Remove space between two note editors in the press release
Please, could you merge develop-theme into develop?.
Thanks